### PR TITLE
Add config to set screen size without react-native-dotenv

### DIFF
--- a/__tests__/config.spec.js
+++ b/__tests__/config.spec.js
@@ -1,0 +1,25 @@
+import Config from "../lib/config";
+
+describe("config", () => {
+  test("default value", () => {
+    expect(Config.get()).toEqual({
+      guidelineBaseWidth: 350,
+      guidelineBaseHeight: 680,
+      alwaysScale: false,
+    });
+  });
+
+  test("set", () => {
+    const scale = jest.fn();
+    Config.set({
+      guidelineBaseWidth: 375,
+      guidelineBaseHeight: 812,
+      alwaysScale: scale,
+    });
+    expect(Config.get()).toEqual({
+      guidelineBaseWidth: 375,
+      guidelineBaseHeight: 812,
+      alwaysScale: scale,
+    });
+  });
+});

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,28 @@
+const createConfig = () => {
+  // Default guideline sizes are based on standard ~5" screen mobile device
+  let defaultGuidelineBaseWidth = 350;
+  let defaultGuidelineBaseHeight = 680;
+
+  // By default, we do not scale value without @ postfix
+  let defaultAlwaysScale = false;
+
+  const set = ({
+    guidelineBaseWidth,
+    guidelineBaseHeight,
+    alwaysScale,
+  } = {}) => {
+    defaultGuidelineBaseWidth = guidelineBaseWidth;
+    defaultGuidelineBaseHeight = guidelineBaseHeight;
+    defaultAlwaysScale = alwaysScale;
+  };
+
+  const get = () => ({
+    guidelineBaseWidth: defaultGuidelineBaseWidth,
+    guidelineBaseHeight: defaultGuidelineBaseHeight,
+    alwaysScale: defaultAlwaysScale,
+  });
+
+  return { set, get };
+};
+
+export default createConfig();

--- a/lib/scaling-utils.js
+++ b/lib/scaling-utils.js
@@ -1,15 +1,19 @@
-import { Dimensions } from 'react-native';
+import { Dimensions } from "react-native";
 
-const { width, height } = Dimensions.get('window');
-const [shortDimension, longDimension] = width < height ? [width, height] : [height, width];
+import Config from "./config";
 
-//Default guideline sizes are based on standard ~5" screen mobile device
-const guidelineBaseWidth = 350;
-const guidelineBaseHeight = 680;
+const { width, height } = Dimensions.get("window");
 
-export const scale = size => shortDimension / guidelineBaseWidth * size;
-export const verticalScale = size => longDimension / guidelineBaseHeight * size;
-export const moderateScale = (size, factor = 0.5) => size + ( scale(size) - size ) * factor;
+const [shortDimension, longDimension] =
+  width < height ? [width, height] : [height, width];
+
+const { guidelineBaseWidth, guidelineBaseHeight } = Config.get();
+
+export const scale = (size) => (shortDimension / guidelineBaseWidth) * size;
+export const verticalScale = (size) =>
+  (longDimension / guidelineBaseHeight) * size;
+export const moderateScale = (size, factor = 0.5) =>
+  size + (scale(size) - size) * factor;
 
 export const s = scale;
 export const vs = verticalScale;


### PR DESCRIPTION
Currently, to customize the base screen size, we have to add library react-native-dotenv. But we prefer react-native-config to bring 12 factors to our app. Besides, such small config should not depend on an external library.

This PR is to provide a Config object for consumers to define their own screens size. To use it. We only have to create a config file:

```
// sizeMattersConfig.js
import { Config } from 'react-native-size-matters'

Config.set({ guidelineBaseWidth: 375, guidelineBaseHeight: 812 }) // iPhone X
```
then import this file in their 'index.js` or `App.js` file.

With this implementation, it will be backward compatible with older versions that use react-native-dotenv