### PR TITLE
Add alwaysScale config and not scale annotation

### DIFF
--- a/__tests__/ScaledSheet.spec.js
+++ b/__tests__/ScaledSheet.spec.js
@@ -1,110 +1,145 @@
-jest.mock('react-native');
-import { ScaledSheet, scale, verticalScale, moderateScale } from '..';
+import Config from "../lib/config";
 
-const getRandomInt = (min = 1, max = 100) => Math.floor(Math.random() * (max - min + 1)) + min;
+jest.mock("react-native");
+import { ScaledSheet, scale, verticalScale, moderateScale } from "..";
 
-describe('ScaledSheet', () => {
-    test('Scale works', () => {
+const getRandomInt = (min = 1, max = 100) =>
+  Math.floor(Math.random() * (max - min + 1)) + min;
+
+describe("ScaledSheet", () => {
+  test("Not number works", () => {
+    const input = { color: "black" };
+    expect(ScaledSheet.create(input).color).toBe("black");
+  });
+
+  test("No scale works", () => {
+    const number = getRandomInt();
+    const input = { test: `${number}@n` };
+    expect(ScaledSheet.create(input).test).toBe(number);
+  });
+
+  test("Scale works", () => {
+    const number = getRandomInt();
+    const input = { test: `${number}@s` };
+    expect(ScaledSheet.create(input).test).toBe(scale(number));
+  });
+
+  test("verticalScale works", () => {
+    const number = getRandomInt();
+    const input = { test: `${number}@vs` };
+    expect(ScaledSheet.create(input).test).toBe(verticalScale(number));
+  });
+
+  test("moderateScale with default factor works", () => {
+    const number = getRandomInt();
+    const input = { test: `${number}@ms` };
+    expect(ScaledSheet.create(input).test).toBe(moderateScale(number));
+  });
+
+  test("moderateScale with custom factor works", () => {
+    const number = getRandomInt();
+    const input = { test: `${number}@ms0.7` };
+    expect(ScaledSheet.create(input).test).toBe(moderateScale(number, 0.7));
+  });
+
+  test("Scale works with a negative value", () => {
+    const number = getRandomInt(-100, -1);
+    const input = { test: `${number}@s` };
+    expect(ScaledSheet.create(input).test).toBe(scale(number));
+  });
+
+  test("moderateScale works with a negative value", () => {
+    const number = getRandomInt(-100, -1);
+    const input = { test: `${number}@ms0.3` };
+    expect(ScaledSheet.create(input).test).toBe(moderateScale(number, 0.3));
+  });
+
+  test("Scale works on a deeply nested object", () => {
+    const number = getRandomInt();
+    const input = { test: { test: { test: `${number}@s` } } };
+    expect(ScaledSheet.create(input).test.test.test).toBe(scale(number));
+  });
+
+  describe("No special annotation", () => {
+    describe("with no Config.alwaysScale", () => {
+      test("should leave the number intact", () => {
         const number = getRandomInt();
-        const input = { test: `${number}@s` }
-        expect(ScaledSheet.create(input).test).toBe(scale(number));
-    });
-
-    test('verticalScale works', () => {
-        const number = getRandomInt();
-        const input = { test: `${number}@vs` }
-        expect(ScaledSheet.create(input).test).toBe(verticalScale(number));
-    });
-
-    test('moderateScale with default factor works', () => {
-        const number = getRandomInt();
-        const input = { test: `${number}@ms` }
-        expect(ScaledSheet.create(input).test).toBe(moderateScale(number));
-    });
-
-    test('moderateScale with custom factor works', () => {
-        const number = getRandomInt();
-        const input = { test: `${number}@ms0.7` }
-        expect(ScaledSheet.create(input).test).toBe(moderateScale(number, 0.7));
-    });
-
-    test('Scale works with a negative value', () => {
-        const number = getRandomInt(-100, -1);
-        const input = { test: `${number}@s` }
-        expect(ScaledSheet.create(input).test).toBe(scale(number));
-    });
-
-    test('moderateScale works with a negative value', () => {
-        const number = getRandomInt(-100, -1);
-        const input = { test: `${number}@ms0.3` }
-        expect(ScaledSheet.create(input).test).toBe(moderateScale(number, 0.3));
-    });
-
-    test('Scale works on a deeply nested object', () => {
-        const number = getRandomInt();
-        const input = { test: { test: { test: `${number}@s` } } }
-        expect(ScaledSheet.create(input).test.test.test).toBe(scale(number));
-    });
-
-    test('No special annotation should leave the number intact', () => {
-        const number = getRandomInt();
-        const input = { test: number }
+        const input = { test: number };
         expect(ScaledSheet.create(input).test).toBe(number);
+      });
     });
 
-    test('ScaledSheet should map a complete StyleSheet with special annotations', () => {
-        const input = {
-            container: {
-                width: '30@s',
-                height: '50@vs',
-                margin: {
-                    width: 12,
-                    height: '12@s',
-                    paddingBottom: -1
-                }
-            },
-            row: {
-                padding: '10@ms0.3',
-                height: '34@ms',
-                marginRight: '0.5@ms0.9',
-                marginLeft: '-0.5@ms0.9',
-                marginBottom: '0.532@ms0.9',
-                marginTop: '-10@s',
-            },
-            round: {
-                top: '11.3@sr',
-                bottom: '22.75@vsr',
-                left: '35.1@msr',
-                right: '-20.19@ms0.3r'
-            }
-        };
+    describe("with Config.alwaysScale", () => {
+      beforeEach(() => {
+        Config.set({ alwaysScale: scale });
+      });
+      afterEach(() => {
+        Config.set({ alwaysScale: false });
+      });
 
-        const expectedOutput = {
-            container: {
-                width: scale(30),
-                height: verticalScale(50),
-                margin: {
-                    width: 12,
-                    height: scale(12),
-                    paddingBottom: -1
-                }
-            },
-            row: {
-                padding: moderateScale(10, 0.3),
-                height: moderateScale(34),
-                marginRight: moderateScale(0.5, 0.9),
-                marginLeft: moderateScale(-0.5, 0.9),
-                marginBottom: moderateScale(0.532, 0.9),
-                marginTop: scale(-10),
-            },
-            round: {
-                top: Math.round(scale(11.3)),
-                bottom: Math.round(verticalScale(22.75)),
-                left: Math.round(moderateScale(35.1)),
-                right: Math.round(moderateScale(-20.19, 0.3))
-            }
-        };
-
-        expect(JSON.stringify(ScaledSheet.create(input))).toBe(JSON.stringify(expectedOutput));
+      test("should scale the number", () => {
+        const number = getRandomInt();
+        const input = { test: number };
+        expect(ScaledSheet.create(input).test).toBe(scale(number));
+      });
     });
-})
+  });
+
+  test("ScaledSheet should map a complete StyleSheet with special annotations", () => {
+    const input = {
+      container: {
+        width: "30@s",
+        height: "50@vs",
+        margin: {
+          width: 12,
+          height: "12@s",
+          paddingBottom: -1,
+        },
+      },
+      row: {
+        padding: "10@ms0.3",
+        height: "34@ms",
+        marginRight: "0.5@ms0.9",
+        marginLeft: "-0.5@ms0.9",
+        marginBottom: "0.532@ms0.9",
+        marginTop: "-10@s",
+      },
+      round: {
+        top: "11.3@sr",
+        bottom: "22.75@vsr",
+        left: "35.1@msr",
+        right: "-20.19@ms0.3r",
+      },
+    };
+
+    const expectedOutput = {
+      container: {
+        width: scale(30),
+        height: verticalScale(50),
+        margin: {
+          width: 12,
+          height: scale(12),
+          paddingBottom: -1,
+        },
+      },
+      row: {
+        padding: moderateScale(10, 0.3),
+        height: moderateScale(34),
+        marginRight: moderateScale(0.5, 0.9),
+        marginLeft: moderateScale(-0.5, 0.9),
+        marginBottom: moderateScale(0.532, 0.9),
+        marginTop: scale(-10),
+      },
+      round: {
+        top: Math.round(scale(11.3)),
+        bottom: Math.round(verticalScale(22.75)),
+        left: Math.round(moderateScale(35.1)),
+        right: Math.round(moderateScale(-20.19, 0.3)),
+      },
+    };
+
+    expect(JSON.stringify(ScaledSheet.create(input))).toBe(
+      JSON.stringify(expectedOutput)
+    );
+  });
+});

--- a/lib/ScaledSheet.js
+++ b/lib/ScaledSheet.js
@@ -1,43 +1,55 @@
-import { StyleSheet } from 'react-native';
-import deepMap from './deep-map';
+import { StyleSheet } from "react-native";
 
-const validScaleSheetRegex = /^(\-?\d+(\.\d{1,3})?)@(ms(\d+(\.\d{1,2})?)?|s|vs)(r?)$/;
+import Config from "./config";
+import deepMap from "./deep-map";
+
+const validScaleSheetRegex = /^(\-?\d+(\.\d{1,3})?)(@(ms(\d+(\.\d{1,2})?)?|s|vs|n)(r?))?$/;
 
 const scaleByAnnotation = (scale, verticalScale, moderateScale) => (value) => {
-    if (!validScaleSheetRegex.test(value)) {
-        return value;
-    }
+  if (!validScaleSheetRegex.test(value)) {
+    return value;
+  }
 
-    const regexExecResult = validScaleSheetRegex.exec(value);
-    const size = parseFloat(regexExecResult[1]);
-    const scaleFunc = regexExecResult[3];
-    const shouldRound = value.endsWith('r');
+  const regexExecResult = validScaleSheetRegex.exec(value);
+  const size = parseFloat(regexExecResult[1]);
+  const scaleFunc = regexExecResult[4];
+  const shouldRound = typeof value === "string" ? value.endsWith("r") : false;
 
-    let result;
+  let result;
 
-    switch (scaleFunc) {
-        case 's':
-            result = scale(size);
-            break;
-        case 'vs':
-            result = verticalScale(size);
-            break;
-        case 'ms':
-            result = moderateScale(size);
-            break;
-        default:
-            const scaleFactor = value.split('ms')[1].replace('r', '');
-            result = moderateScale(size, parseFloat(scaleFactor));
-    }
+  switch (scaleFunc) {
+    case "n":
+      return size;
+    case undefined:
+      const { alwaysScale } = Config.get();
+      if (alwaysScale) {
+        result = alwaysScale(size);
+        break;
+      } else {
+        return size;
+      }
+    case "s":
+      result = scale(size);
+      break;
+    case "vs":
+      result = verticalScale(size);
+      break;
+    case "ms":
+      result = moderateScale(size);
+      break;
+    default:
+      const scaleFactor = value.split("ms")[1].replace("r", "");
+      result = moderateScale(size, parseFloat(scaleFactor));
+  }
 
-    return shouldRound ? Math.round(result) : result;
+  return shouldRound ? Math.round(result) : result;
 };
 
 const scaledSheetCreator = (scale, verticalScale, moderateScale) => {
-    const scaleFunc = scaleByAnnotation(scale, verticalScale, moderateScale);
-    return {
-        create: styleSheet => StyleSheet.create(deepMap(styleSheet, scaleFunc))
-    }
-}
+  const scaleFunc = scaleByAnnotation(scale, verticalScale, moderateScale);
+  return {
+    create: (styleSheet) => StyleSheet.create(deepMap(styleSheet, scaleFunc)),
+  };
+};
 
 export default scaledSheetCreator;


### PR DESCRIPTION
Currently, if we have to scale a value, we  have to add post fix to it, something like `{padding: "10@s"}`. But in our project, we have to scale all the value automatically without any annotation. This PR is to add a config name `alwaysScale` which receives a scale function. It may be scale, verticalScale or moderateScale. If it's present, all the number value will be scale auto automatically in ScaleSheeet.

The above option leads to a scenario that there are some values we don't want to scale. In that case, all we have to do is add postfix `@n` to it, like `margin: "15@n"` and this value 15 will not be scaled.