### PR TITLE
Add IGNORE_STYLES constant to ignore scale for style like `flex`

### DIFF
--- a/__tests__/ScaledSheet.spec.js
+++ b/__tests__/ScaledSheet.spec.js
@@ -12,6 +12,11 @@ describe("ScaledSheet", () => {
     expect(ScaledSheet.create(input).color).toBe("black");
   });
 
+  test("Ignore styles works", () => {
+    const input = { flex: 2 };
+    expect(ScaledSheet.create(input).flex).toBe(2);
+  });
+
   test("No scale works", () => {
     const number = getRandomInt();
     const input = { test: `${number}@n` };

--- a/lib/ScaledSheet.js
+++ b/lib/ScaledSheet.js
@@ -5,8 +5,13 @@ import deepMap from "./deep-map";
 
 const validScaleSheetRegex = /^(\-?\d+(\.\d{1,3})?)(@(ms(\d+(\.\d{1,2})?)?|s|vs|n)(r?))?$/;
 
-const scaleByAnnotation = (scale, verticalScale, moderateScale) => (value) => {
-  if (!validScaleSheetRegex.test(value)) {
+const IGNORE_STYLES = ["flex"];
+
+const scaleByAnnotation = (scale, verticalScale, moderateScale) => (
+  value,
+  key
+) => {
+  if (!validScaleSheetRegex.test(value) || IGNORE_STYLES.includes(key)) {
     return value;
   }
 

--- a/lib/deep-map.js
+++ b/lib/deep-map.js
@@ -1,20 +1,20 @@
 const deepMap = (obj, fn) => {
-    const deepMapper = val => (isObject(val)) ? deepMap(val, fn) : fn(val);
-    if (Array.isArray(obj)) {
-        return obj.map(deepMapper);
-    }
-    if (isObject(obj)) {
-        return mapObject(obj, deepMapper);
-    }
-    return obj;
+  const deepMapper = (val) => (isObject(val) ? deepMap(val, fn) : fn(val));
+  if (Array.isArray(obj)) {
+    return obj.map(deepMapper);
+  }
+  if (isObject(obj)) {
+    return mapObject(obj, deepMapper);
+  }
+  return obj;
 };
 
-const mapObject = (obj, fn) => Object.keys(obj).reduce(
-    (res, key) => {
-        res[key] = fn(obj[key]);
-        return res;
-    }, {});
+const mapObject = (obj, fn) =>
+  Object.keys(obj).reduce((res, key) => {
+    res[key] = fn(obj[key], key);
+    return res;
+  }, {});
 
-const isObject = myVar => myVar && typeof myVar === 'object';
+const isObject = (myVar) => myVar && typeof myVar === "object";
 
 export default deepMap;


### PR DESCRIPTION
Since we allow consumers to auto scale the style without `@s` annotation, values like `flex: 3` will be scaled. This PR is to ignore flex value. Other values, if any, will be added later.